### PR TITLE
Add sqlx support and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ default = ["serde"]
 
 [dev-dependencies]
 serde_json = "1.0.91"
+sqlx = { version = "0.8.2", features = ["sqlite", "runtime-tokio"] }
+tokio = { version = "1.40.0", features = ["macros", "rt"] }

--- a/src/fract_index.rs
+++ b/src/fract_index.rs
@@ -1,7 +1,9 @@
 use crate::hex::{bytes_to_hex, hex_to_bytes};
 use std::{
+    convert::TryFrom,
     error::Error,
     fmt::{self, Display},
+    ops::Deref,
 };
 
 #[cfg(feature = "serde")]
@@ -246,6 +248,33 @@ impl FractionalIndex {
             // They are equal.
             None
         }
+    }
+}
+
+impl TryFrom<Vec<u8>> for FractionalIndex {
+    type Error = DecodeError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        FractionalIndex::from_bytes(bytes)
+    }
+}
+
+impl TryFrom<Option<Vec<u8>>> for FractionalIndex {
+    type Error = DecodeError;
+
+    fn try_from(bytes: Option<Vec<u8>>) -> Result<Self, Self::Error> {
+        match bytes {
+            Some(bytes) => FractionalIndex::from_bytes(bytes),
+            None => Ok(FractionalIndex::default()),
+        }
+    }
+}
+
+impl Deref for FractionalIndex {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/tests/migrations/20240916125310_sqlx-test-schema.sql
+++ b/tests/migrations/20240916125310_sqlx-test-schema.sql
@@ -1,0 +1,7 @@
+
+create table "item" (
+    "id" integer primary key autoincrement,
+    "name" text not null,
+    "fractional_index" blob not null,
+    "nullable_fractional_index" blob
+);

--- a/tests/migrations/20240916125310_sqlx-test-schema.sql
+++ b/tests/migrations/20240916125310_sqlx-test-schema.sql
@@ -1,7 +1,0 @@
-
-create table "item" (
-    "id" integer primary key autoincrement,
-    "name" text not null,
-    "fractional_index" blob not null,
-    "nullable_fractional_index" blob
-);

--- a/tests/sqlx.rs
+++ b/tests/sqlx.rs
@@ -1,0 +1,105 @@
+use fractional_index::FractionalIndex;
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::FromRow;
+
+#[derive(FromRow, Debug)]
+struct Item {
+    #[allow(unused)]
+    id: i64,
+    name: String,
+    #[sqlx(try_from = "Vec<u8>")]
+    fractional_index: FractionalIndex,
+    #[sqlx(try_from = "Option<Vec<u8>>")]
+    nullable_fractional_index: FractionalIndex,
+}
+
+#[tokio::test]
+async fn sqlx_insert_select() {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    // Create table.
+    sqlx::migrate!("tests/migrations").run(&pool).await.unwrap();
+
+    let idx2 = FractionalIndex::new_after(&FractionalIndex::default());
+
+    // Insert an item.
+    sqlx::query("insert into item (name, fractional_index) values (?, ?)")
+        .bind("item1")
+        .bind(&*idx2)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Fetch all items
+    let mut items: Vec<Item> = sqlx::query_as("select * from item")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 1);
+    let item = items.pop().unwrap();
+
+    assert_eq!(item.name, "item1");
+    assert_eq!(item.fractional_index, idx2);
+}
+
+#[tokio::test]
+async fn sqlx_insert_select_nullable() {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    // Create table.
+    sqlx::migrate!("tests/migrations").run(&pool).await.unwrap();
+
+    let idx2 = FractionalIndex::new_after(&FractionalIndex::default());
+    let idx3 = FractionalIndex::new_after(&idx2);
+
+    // Insert an item.
+    sqlx::query(
+        "insert into item (name, fractional_index, nullable_fractional_index) values (?, ?, ?)",
+    )
+    .bind("item1")
+    .bind(&*idx2)
+    .bind(&*idx3)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "insert into item (name, fractional_index, nullable_fractional_index) values (?, ?, NULL)",
+    )
+    .bind("item2")
+    .bind(&*idx3)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Fetch all items
+    let items: Vec<Item> = sqlx::query_as("select * from item order by id asc")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    let mut items = items.into_iter();
+
+    {
+        let item = items.next().unwrap();
+        assert_eq!(item.name, "item1");
+        assert_eq!(item.fractional_index, idx2);
+        assert_eq!(item.nullable_fractional_index, idx3);
+    }
+
+    {
+        let item = items.next().unwrap();
+        assert_eq!(item.name, "item2");
+        assert_eq!(item.fractional_index, idx3);
+        assert_eq!(item.nullable_fractional_index, FractionalIndex::default());
+    }
+
+    assert!(items.next().is_none());
+}

--- a/tests/sqlx.rs
+++ b/tests/sqlx.rs
@@ -2,6 +2,14 @@ use fractional_index::FractionalIndex;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::FromRow;
 
+const CREATE_TABLE_QUERY: &str = r#"
+    create table item (
+        id integer primary key,
+        name text not null,
+        fractional_index blob not null,
+        nullable_fractional_index blob
+    )"#;
+
 #[derive(FromRow, Debug)]
 struct Item {
     #[allow(unused)]
@@ -21,7 +29,10 @@ async fn sqlx_insert_select() {
         .unwrap();
 
     // Create table.
-    sqlx::migrate!("tests/migrations").run(&pool).await.unwrap();
+    sqlx::query(CREATE_TABLE_QUERY)
+        .execute(&pool)
+        .await
+        .unwrap();
 
     let idx2 = FractionalIndex::new_after(&FractionalIndex::default());
 
@@ -54,7 +65,10 @@ async fn sqlx_insert_select_nullable() {
         .unwrap();
 
     // Create table.
-    sqlx::migrate!("tests/migrations").run(&pool).await.unwrap();
+    sqlx::query(CREATE_TABLE_QUERY)
+        .execute(&pool)
+        .await
+        .unwrap();
 
     let idx2 = FractionalIndex::new_after(&FractionalIndex::default());
     let idx3 = FractionalIndex::new_after(&idx2);


### PR DESCRIPTION
This is an alternative approach to #7. It adds support for use in an `sqlx` `AsRow` derive, by implementing `TryFrom<Vec<u8>>` and `TryFrom<Option<Vec<u8>>>`.

One limitation of this approach is that for a nullable column, we can only return a `FractionalIndex`, not an `Option<FractionalIndex>`. I wish `sqlx` would implement something like `#[sqlx(try_from_option = "Vec<u8>")]` that would handle nullable columns by returning a `None`, but unfortunately this seems to be the best we can do.

This also improves the ergonomics of inserting a `FractionalIndex`, by implementing `Deref`.

This adds tests using `sqlx` and `sqlite`, which double as a demonstration of a usage example.